### PR TITLE
Incorrect links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,11 @@ Links
 
 
 .. _Raspberry Pi: https://www.raspberrypi.org/
-.. _camera: https://www.raspberrypi.org/learning/getting-started-with-picamerax/
+.. _camera: https://www.raspberrypi.org/learning/getting-started-with-picamera/
 .. _PyPI: https://pypi.python.org/pypi/picamerax/
 .. _documentation: https://picamerax.readthedocs.io/
-.. _source code: https://github.com/waveform80/picamerax
-.. _bug tracker: https://github.com/waveform80/picamerax/issues
+.. _source code: https://github.com/labthings/picamerax
+.. _bug tracker: https://github.com/labthings/picamerax/issues
 .. _BSD license: https://opensource.org/licenses/BSD-3-Clause
 
 Developer notes


### PR DESCRIPTION
README has the documentation and source code links from the waveform80 repo