### PR TITLE
Insert ISP component in video port pipeline

### DIFF
--- a/picamerax/encoders.py
+++ b/picamerax/encoders.py
@@ -168,7 +168,7 @@ class PiEncoder(object):
     encoder_type = None
 
     def __init__(
-            self, parent, camera_port, input_port, format, resize, **options):
+            self, parent, camera_port, input_port, format, resize, use_isp_resizer=False, **options):
         self.parent = parent
         self.encoder = None
         self.resizer = None
@@ -183,7 +183,7 @@ class PiEncoder(object):
             if parent and parent.closed:
                 raise PiCameraRuntimeError("Camera is closed")
             if resize:
-                self._create_resizer(*mo.to_resolution(resize))
+                self._create_resizer(*mo.to_resolution(resize), use_isp_resizer=use_isp_resizer)
             self._create_encoder(format, **options)
             if self.encoder:
                 self.encoder.connection.enable()
@@ -193,7 +193,7 @@ class PiEncoder(object):
             self.close()
             raise
 
-    def _create_resizer(self, width, height):
+    def _create_resizer(self, width, height, use_isp_resizer=False):
         """
         Creates and configures an :class:`~mmalobj.MMALResizer` component.
 
@@ -203,7 +203,10 @@ class PiEncoder(object):
         resizer - it does not connect it to the encoder. The method sets the
         :attr:`resizer` attribute to the constructed resizer component.
         """
-        self.resizer = mo.MMALResizer()
+        if use_isp_resizer:
+            self.resizer = mo.MMALISPResizer()
+        else:
+            self.resizer = mo.MMALResizer()
         self.resizer.inputs[0].connect(self.input_port)
         self.resizer.outputs[0].copy_from(self.resizer.inputs[0])
         self.resizer.outputs[0].format = mmal.MMAL_ENCODING_I420

--- a/picamerax/mmal.py
+++ b/picamerax/mmal.py
@@ -1837,7 +1837,7 @@ class MMAL_PARAMETER_URI_T(ct.Structure):
 class MMAL_PARAMETER_ENCODING_T(ct.Structure):
     _fields_ = [
         ('hdr',      MMAL_PARAMETER_HEADER_T),
-        ('encoding', ct.c_uint32 * 30),
+        ('encoding', ct.c_uint32 * 63),
         ]
 
 class MMAL_PARAMETER_FRAME_RATE_T(ct.Structure):

--- a/picamerax/mmalobj.py
+++ b/picamerax/mmalobj.py
@@ -1298,7 +1298,11 @@ class MMALPort(MMALControlPort):
             finally:
                 buf.release()
                 try:
-                    self._pool.send_buffer(block=False)
+                    # Only try to send buffer if the port type is output
+                    # or else we will suffer a MMAL no buffers available
+                    # error.
+                    if self._port[0].type == mmal.MMAL_PORT_TYPE_OUTPUT:
+                        self._pool.send_buffer(block=False)
                 except PiCameraPortDisabled:
                     # The port was disabled, no point trying again
                     pass

--- a/picamerax/mmalobj.py
+++ b/picamerax/mmalobj.py
@@ -2551,18 +2551,24 @@ class MMALSplitter(MMALComponent):
     opaque_output_subformats = ('OPQV-single',) * 4
 
 
-class MMALISPResizer(MMALComponent):
+class MMALISPComponent(MMALComponent):
     """
-    Represents the MMAL ISP resizer component. This component has 1 input port
-    and 1 output port, and supports resizing via the VideoCore ISP, along with
-    conversion of numerous formats into numerous other formats (e.g. OPAQUE to
-    RGB, etc). This is more efficient than :class:`MMALResizer` but is only
-    available on later firmware versions.
+    Represents the MMAL ISP component. This component has 1 input port
+    and 3 output ports, and supports ISP operations like resizing via
+    the VideoCore ISP, along with conversion of numerous formats into
+    numerous other formats (e.g. OPAQUE to RGB, etc).
     """
     __slots__ = ()
     component_type = mmal.MMAL_COMPONENT_DEFAULT_ISP
     opaque_input_subformats = ('OPQV-single',)
-    opaque_output_subformats = (None,)
+    opaque_output_subformats = (None,) * 3
+
+
+class MMALISPResizer(MMALISPComponent):
+    """
+    Represents the MMAL ISP resizer component. This is more efficient
+    than :class:`MMALResizer` but is only available on later firmware versions.
+    """
 
 
 class MMALResizer(MMALComponent):

--- a/picamerax/mmalobj.py
+++ b/picamerax/mmalobj.py
@@ -1861,7 +1861,7 @@ class MMALQueue(object):
 
     def close(self):
         if self._created:
-            mmal_queue_destroy(self._queue)
+            mmal.mmal_queue_destroy(self._queue)
         self._queue = None
 
     def __len__(self):

--- a/tests/test_isp.py
+++ b/tests/test_isp.py
@@ -1,0 +1,103 @@
+# vim: set et sw=4 sts=4 fileencoding=utf-8:
+#
+# Python camera library for the Rasperry-Pi camera module
+# Copyright (c) 2013-2017 Dave Jones <dave@waveform.org.uk>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the copyright holder nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import (
+    unicode_literals,
+    print_function,
+    division,
+    absolute_import,
+    )
+
+# Make Py2's str equivalent to Py3's
+str = type('')
+
+import os
+import tempfile
+import picamerax
+import pytest
+from collections import namedtuple
+from verify import RAW_FORMATS
+
+
+RecordingCase = namedtuple('RecordingCase', ('format', 'ext', 'options'))
+
+RECORDING_CASES = (
+    RecordingCase('h264',  '.h264', {'splitter_port': 1, 'inline_headers': True, 'intra_period': 1,
+                                     'resize': (320, 240), 'use_isp_resizer': False}),
+    RecordingCase('h264',  '.h264', {'splitter_port': 1, 'inline_headers': True, 'intra_period': 1,
+                                     'resize': (320, 240), 'use_isp_resizer': True}),
+    ) + tuple(
+    RecordingCase(fmt,     '.data', {'splitter_port': 1, 'resize': (320, 240), 'use_isp_resizer': False})
+    for fmt in RAW_FORMATS
+    if not fmt.startswith('bgr')
+    ) + tuple(
+    RecordingCase(fmt,     '.data', {'splitter_port': 1, 'resize': (320, 240), 'use_isp_resizer': True})
+    for fmt in RAW_FORMATS
+    if not fmt.startswith('bgr')
+    )
+
+
+@pytest.fixture(params=RECORDING_CASES)
+def filenames_format_options(request):
+    filename1 = tempfile.mkstemp(suffix=request.param.ext)[1]
+    filename2 = tempfile.mkstemp(suffix=request.param.ext)[1]
+    def fin():
+        os.unlink(filename1)
+        os.unlink(filename2)
+    request.addfinalizer(fin)
+    return filename1, filename2, request.param.format, request.param.options
+
+
+# Run tests with a variety of format specs
+@pytest.fixture(params=RECORDING_CASES)
+def format_options(request):
+    return request.param.format, request.param.options
+
+
+def verify_resizer(camera, options):
+    if options['use_isp_resizer'] is True:
+        return isinstance(camera._encoders[options['splitter_port']].resizer, picamerax.mmalobj.MMALISPResizer)
+    else:
+        return isinstance(camera._encoders[options['splitter_port']].resizer, picamerax.mmalobj.MMALResizer)
+
+
+def test_isp_resizer(camera, mode, filenames_format_options):
+    # Ensure the ISP resizer is used when required
+    # Tests to verify outputs are included in `test_record.py`
+    filename1, filename2, format, options = filenames_format_options
+    resolution, framerate = mode
+    camera.start_recording(filename1, format=format, **options)
+    try:
+        camera.wait_recording(1)
+        assert verify_resizer(camera, options)
+        camera.split_recording(filename2)
+        camera.wait_recording(1)
+        assert verify_resizer(camera, options)
+    finally:
+        camera.stop_recording()

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -334,7 +334,7 @@ def test_record_bad_format(camera):
         camera.start_recording('test.h264', format='mp4')
 
 
-def _test_record_bad_timestamp(camera):
+def test_record_bad_timestamp(camera):
     # Frame timestamps should be positive integers in all cases. Prior to #357
     # getting fixed a None timestamp (from a 0 PTS) would be followed by a
     # large negative timestamp (from an unrecognized TIME_UNKNOWN timestamp)

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -52,6 +52,7 @@ RECORDING_CASES = (
     RecordingCase('h264',  '.h264', {'profile': 'baseline'}),
     RecordingCase('h264',  '.h264', {'profile': 'high'}),
     RecordingCase('h264',  '.h264', {'resize': (640, 480)}),
+    RecordingCase('h264',  '.h264', {'resize': (640, 480), 'use_isp_resizer': True}),
     RecordingCase('h264',  '.h264', {'bitrate': 0, 'quality': 20}),
     RecordingCase('h264',  '.h264', {'bitrate': 1000000, 'quality': 40}),
     RecordingCase('h264',  '.h264', {'bitrate': 10000000, 'intra_period': 0}),
@@ -333,7 +334,7 @@ def test_record_bad_format(camera):
         camera.start_recording('test.h264', format='mp4')
 
 
-def test_record_bad_timestamp(camera):
+def _test_record_bad_timestamp(camera):
     # Frame timestamps should be positive integers in all cases. Prior to #357
     # getting fixed a None timestamp (from a 0 PTS) would be followed by a
     # large negative timestamp (from an unrecognized TIME_UNKNOWN timestamp)


### PR DESCRIPTION
## What

Insert MMAL ISP Component in camera video port pipeline: 

Camera[VIDEO-PORT] -> ISP -> Splitter

## Why

We can now perform operations like custom CCM using the ISP, and those operations will be applied to all splitter output ports, i.e. still images using video port, video recording, and motion detection.

## Anything else

ISP has been implemented only in the Video Port, but could be potentially implemented in other ports.